### PR TITLE
Bugfix: $pn null for non-superusers in repeaters

### DIFF
--- a/RestrictTabView.module
+++ b/RestrictTabView.module
@@ -114,7 +114,9 @@ class RestrictTabView extends WireData implements Module, ConfigurableModule {
         if($tab == "Settings") {
             if(!$this->data['showNameInContentTab']) {
                 $pn = $form->getChildByName('_pw_page_name');
-                $pn->wrapAttr('style', 'display:none;');
+                if ($pn instanceof Inputfield) {
+                    $pn->wrapAttr('style', 'display:none;');
+                }
             }
         }
 


### PR DESCRIPTION
Guard the use of the $pn variable as its unguarded use prevents the addition of new lines to repeater fields.